### PR TITLE
fix head link & eslint article

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -78,8 +78,8 @@ module.exports = {
     {
       resolve: `gatsby-plugin-manifest`,
       options: {
-        name: `gatsby-starter-default`,
-        short_name: `starter`,
+        name: `blog.ojisan.io`,
+        short_name: `blog`,
         start_url: `/`,
         background_color: `#663399`,
         theme_color: `#663399`,
@@ -97,11 +97,6 @@ module.exports = {
       resolve: `gatsby-transformer-remark`,
       options: {
         plugins: [
-          // NOTE: title を前におく必要あり
-          {
-            resolve: "gatsby-remark-code-titles",
-            options: {},
-          },
           {
             resolve: `gatsby-remark-prismjs`,
             options: {

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -97,6 +97,11 @@ module.exports = {
       resolve: `gatsby-transformer-remark`,
       options: {
         plugins: [
+          // NOTE: title を前におく必要あり
+          {
+            resolve: "gatsby-remark-code-titles",
+            options: {},
+          },
           {
             resolve: `gatsby-remark-prismjs`,
             options: {
@@ -126,7 +131,14 @@ module.exports = {
               },
             },
           },
-          `gatsby-remark-autolink-headers`,
+          {
+            resolve: `gatsby-remark-autolink-headers`,
+            options: {
+              // そこにジャンプした時の上からの余白
+              offsetY: `10`,
+              className: `anchor-link`,
+            },
+          },
           {
             resolve: `gatsby-remark-images`,
             options: {

--- a/src/contents/20200615-eslint-plugin-and-extend/index.md
+++ b/src/contents/20200615-eslint-plugin-and-extend/index.md
@@ -1,16 +1,17 @@
 ---
 path: /eslint-plugin-and-extend
 created: "2020-06-15"
-title: ESLint の Plugin と Extends の違い
+updated: "2020-06-15"
+title: ESLint の Plugin と Extend の違い
 visual: "./visual.png"
 ---
 
-ESLint の Plugin と Extends の違いを説明できますか？
-違いを知っている人からすれば（というかそもそも全然違うものなので）、「え、それ悩む？」となるところなのですが、ユーザー向けドキュメントには Plugin の定義が書かれておらず、Extends の説明も不十分で、さらに Plugin の設定をする Extends なんてものがあるお陰で、慣れないうちは混乱すると思います。
+ESLint の Plugin と Extend の違いを説明できますか？
+違いを知っている人からすれば（というかそもそも全然違うものなので）、「え、それ悩む？」となるところなのですが、ユーザー向けドキュメントには Plugin の定義が書かれておらず、Extend の説明も不十分で、さらに Plugin の設定をする Extend なんてものがあるお陰で、慣れないうちは混乱すると思います。
 特に最後の事象は個人的には印象的で、「Plugin の設定をしていないのに Plugin が設定されている。Plugin って何？」といった混乱の原因になっていました。
 この混乱は ESLint の全体感を掴むと混乱しなくなるのでそういう話を書きたいと思います。
 
-結論を言うと、**Extends は Extends です。設定を Extend する役割を持っています。Plugin は Plugin です。設定を Plug する役割を持っています。**
+結論を言うと、**Extend は Extend です。設定を Extend する役割を持っています。Plugin は Plugin です。設定を Plug する役割を持っています。**
 
 ## ESLint はルールを用いてコードを静的検証する
 
@@ -35,8 +36,8 @@ rule を中心に考えると ESLint の理解はしやすくなります。(は
 
 FYI: https://eslint.org/docs/developer-guide/architecture
 
-なぜ Extends と Plugin の説明で rule の話から始めたかと言うと、それらは共に rule を制御する機能だからです。
-**Plugin は rule を追加でき、Extends は rule の setting を設定できます。**
+なぜ Extend と Plugin の説明で rule の話から始めたかと言うと、それらは共に rule を制御する機能だからです。
+**Plugin は rule(つまり静的検証する関数そのもの) を追加でき、Extend は rule の setting を設定できます。**
 
 ## Plugin はルールを追加する
 
@@ -57,13 +58,13 @@ Plugin が何か、ユーザーガイドの [configuring-plugins](https://eslint
 一般的に plugin は何かを注入する機構なので、ここでもそれらを注入してくれるものだと考えておきましょう。
 実際 plugin の実装を読む限りはルールを注入しており、そのような使われた方が多いと言う点は合意が得られると思います。
 
-## Extends の役割について
+## Extend の役割について
 
-Extends の説明を公式ドキュメントで見てみましょう。
+Extend の説明を公式ドキュメントで見てみましょう。
 
 Configuring ESLint というドキュメントの[Extending Configuration Files](https://eslint.org/docs/user-guide/configuring#extending-configuration-files)には A configuration file can extend the set of enabled rules from base configurations.とあり、どうやらルールを拡張できる機能と説明しています。
 
-### Extends はルールの setting をする
+### Extend はルールの setting をする
 
 たとえばこのような設定ファイルがあるとします。
 
@@ -188,7 +189,7 @@ config を自作するときやルールを一部書き換えたい時に使え�
 
 FYI: https://eslint.org/docs/developer-guide/shareable-configs#local-config-file-resolution
 
-### つまり Extends の挙動をまとめると
+### つまり Extend の挙動をまとめると
 
 - .eslintrc.js の extends に指定する値は shareable config(名前もしくは path)
 - plugin は shareable config の提供もできる
@@ -339,5 +340,5 @@ FYI: https://github.com/ojisan-toybox/eslint-plugin-node-config　(実験に使�
 
 ## 結論
 
-**Extends は Extends, その名の通り設定ファイルを拡張するものです。Plugin は Plugin, その名の通り機能を追加するものです。Plugin を使うという設定を内部で Extend できるため、ユーザーは Plugin の設定を書かなくても済んでいる場合があった（そしてそのケースが多い）**というのがことの顛末です。
+**Extend は Extend, その名の通り設定ファイルを拡張するものです。Plugin は Plugin, その名の通り機能を追加するものです。Plugin を使うという設定を内部で Extend できるため、ユーザーは Plugin の設定を書かなくても済んでいる場合があった（そしてそのケースが多い）**というのがことの顛末です。
 ユーザー向けドキュメントからは読み取りにくいところはありますが、プラグインや ESLint そのものの開発者向けドキュメントにはヒントがあったりするので、ESLint で何か詰まったときは開発者向けドキュメントも読んでみると良いかもしれません。

--- a/src/templates/blogTemplate.module.css
+++ b/src/templates/blogTemplate.module.css
@@ -116,13 +116,11 @@
   padding-top: 10vh;
 }
 
-/* ジャンプ時の固定ヘッダ(9vh)ずれ対策(1vhは余白として10vhにしている) */
-.content > h1 > a,
-.content > h2 > a,
-.content > h3 > a,
-.content > h4 > a {
-  /* .anchor.before の詳細度に勝てないのでimportant使う */
-  top: 10vh !important;
+.content a {
+  /* paddingがlinkとなってコピペできないのでそれをやめるために、そもそもリンクを消す。
+  FIXME: リンク機能も欲しいので恒久対応は考える
+  */
+  display: none;
 }
 
 .content > h3,

--- a/types/graphql-types.d.ts
+++ b/types/graphql-types.d.ts
@@ -2586,6 +2586,8 @@ export type SitePageFieldsEnum =
   | 'pluginCreator___pluginOptions___prompt___user'
   | 'pluginCreator___pluginOptions___prompt___host'
   | 'pluginCreator___pluginOptions___prompt___global'
+  | 'pluginCreator___pluginOptions___offsetY'
+  | 'pluginCreator___pluginOptions___className'
   | 'pluginCreator___pluginOptions___maxWidth'
   | 'pluginCreator___pluginOptions___trackingId'
   | 'pluginCreator___pluginOptions___head'
@@ -2787,6 +2789,8 @@ export type SitePluginFieldsEnum =
   | 'pluginOptions___plugins___pluginOptions___showLineNumbers'
   | 'pluginOptions___plugins___pluginOptions___noInlineHighlight'
   | 'pluginOptions___plugins___pluginOptions___languageExtensions'
+  | 'pluginOptions___plugins___pluginOptions___offsetY'
+  | 'pluginOptions___plugins___pluginOptions___className'
   | 'pluginOptions___plugins___pluginOptions___maxWidth'
   | 'pluginOptions___plugins___browserAPIs'
   | 'pluginOptions___plugins___ssrAPIs'
@@ -2819,6 +2823,8 @@ export type SitePluginFieldsEnum =
   | 'pluginOptions___prompt___user'
   | 'pluginOptions___prompt___host'
   | 'pluginOptions___prompt___global'
+  | 'pluginOptions___offsetY'
+  | 'pluginOptions___className'
   | 'pluginOptions___maxWidth'
   | 'pluginOptions___trackingId'
   | 'pluginOptions___head'
@@ -2964,6 +2970,8 @@ export type SitePluginPluginOptions = {
   noInlineHighlight?: Maybe<Scalars['Boolean']>;
   languageExtensions?: Maybe<Array<Maybe<SitePluginPluginOptionsLanguageExtensions>>>;
   prompt?: Maybe<SitePluginPluginOptionsPrompt>;
+  offsetY?: Maybe<Scalars['String']>;
+  className?: Maybe<Scalars['String']>;
   maxWidth?: Maybe<Scalars['Int']>;
   trackingId?: Maybe<Scalars['String']>;
   head?: Maybe<Scalars['Boolean']>;
@@ -3066,6 +3074,8 @@ export type SitePluginPluginOptionsFilterInput = {
   noInlineHighlight?: Maybe<BooleanQueryOperatorInput>;
   languageExtensions?: Maybe<SitePluginPluginOptionsLanguageExtensionsFilterListInput>;
   prompt?: Maybe<SitePluginPluginOptionsPromptFilterInput>;
+  offsetY?: Maybe<StringQueryOperatorInput>;
+  className?: Maybe<StringQueryOperatorInput>;
   maxWidth?: Maybe<IntQueryOperatorInput>;
   trackingId?: Maybe<StringQueryOperatorInput>;
   head?: Maybe<BooleanQueryOperatorInput>;
@@ -3121,6 +3131,8 @@ export type SitePluginPluginOptionsPluginsPluginOptions = {
   noInlineHighlight?: Maybe<Scalars['Boolean']>;
   languageExtensions?: Maybe<Array<Maybe<SitePluginPluginOptionsPluginsPluginOptionsLanguageExtensions>>>;
   prompt?: Maybe<SitePluginPluginOptionsPluginsPluginOptionsPrompt>;
+  offsetY?: Maybe<Scalars['String']>;
+  className?: Maybe<Scalars['String']>;
   maxWidth?: Maybe<Scalars['Int']>;
 };
 
@@ -3130,6 +3142,8 @@ export type SitePluginPluginOptionsPluginsPluginOptionsFilterInput = {
   noInlineHighlight?: Maybe<BooleanQueryOperatorInput>;
   languageExtensions?: Maybe<SitePluginPluginOptionsPluginsPluginOptionsLanguageExtensionsFilterListInput>;
   prompt?: Maybe<SitePluginPluginOptionsPluginsPluginOptionsPromptFilterInput>;
+  offsetY?: Maybe<StringQueryOperatorInput>;
+  className?: Maybe<StringQueryOperatorInput>;
   maxWidth?: Maybe<IntQueryOperatorInput>;
 };
 


### PR DESCRIPTION
- 見出しのリンク消した（リンクのズレを直すpaddingが邪魔してコピペできなくなってる）
- extends => extend に統一
- plugin の定義を少し丁寧に 