### PR TITLE
titleTemplateを削除する

### DIFF
--- a/src/components/seo.tsx
+++ b/src/components/seo.tsx
@@ -34,7 +34,6 @@ function SEO({ description, meta, title, image }: IProps & SeoQuery) {
         lang: "ja",
       }}
       title={title}
-      titleTemplate={`%s | ${site.siteMetadata.title}`}
       meta={[
         {
           name: `description`,


### PR DESCRIPTION
いつも参考になるブログ記事ありがとうございます。
これは提案プルリクエストです。以下は提案の理由です。

## Share on Twitterなどの`<title>` タグをもとにツイートを生成される場合

ブログ記事内にTwitterの共有リンクはありますが、
自分のように[Share on Twitter](https://chrome.google.com/webstore/detail/share-on-twitter/gkjgmeeoldebbdoehhngapnlfmdbmiie?hl=ja)というGoogle拡張機能みたいなものでツイートしている場合以下のようになります。

<img src="https://i.gyazo.com/684e6ac670b3142e45e04ad8bb41c04c.png" alt="Twitterでblog.ojisan.ioの記事を共有するスクリーンショット" width="450">

一見するとわかりづらいかもですが、TOPページ（`https://blog.ojisan.io/`）のOGPが優先されたTwitterカードが生成されます。
本来であれば後者のURLが優先されて生成されるべきです。
詳しい仕様はわからないのですが、前は後者のURLが優先されていたのですが最近Twitter側で変更されたようです。
Twitterに合わせろというわけではないのですが、ブログのTwitterの共有リンクでも含んでないので統一してもよいのではないのか、と思います。

## TOPページの場合ダブる

<img width="325" alt="<title>blog.ojisan.io | blog.ojisan.io</title>のスクリーンショット" src="https://user-images.githubusercontent.com/1996642/87147728-1b090a80-c2e8-11ea-9f45-b2629cb994bf.png">

１個で良くないスか

---

とはいえ、タイトルから象徴たるものがなくなると[Google検索としても弱くなるかも](https://support.google.com/webmasters/answer/35624?hl=ja)ので
URLの代わりにそろそろ正式なブログタイトルをそこに入れるというのも良さそうですね。
というわけでご確認お願いいたします :pray:

関連
- https://github.com/yamanoku/yamanoku.github.io/issues/330
- https://mya-ake.com/posts/join-mercari/
  - `mya-ake com` になっている