### PR TITLE
fix typo

### DIFF
--- a/src/contents/202009013-s-c-kigo/index.md
+++ b/src/contents/202009013-s-c-kigo/index.md
@@ -174,7 +174,7 @@ selector:pseudo-class {
 :: は擬似要素(Pseudo-elements)を表すのに使います。
 MDN の説明を借りるなら、擬似要素 Pseudo-elements はセレクターに付加するキーワードで、選択された要素の特定の部分にスタイル付けできるようにするものです。
 
-FYI: https://developer.mozilla.org/ja/docs/Web/CSS/Pseudo-classes
+FYI: https://developer.mozilla.org/ja/docs/Web/CSS/Pseudo-elements
 
 ```css
 selector::pseudo-element {


### PR DESCRIPTION
[styled-components の :&>before(記号) まとめ](https://blog.ojisan.io/s-c-kigo#hogebefore) で擬似要素に関する MDN のリンクが擬似クラスのものになっていたので、その修正です。

いつもためになるなと思って読ませてもらってます！

