### PR TITLE
`noreferrer noreferrer` を `noopener noreferrer` に修正

### DIFF
--- a/src/contents/20200918-noreferrer-noopener/index.md
+++ b/src/contents/20200918-noreferrer-noopener/index.md
@@ -27,10 +27,10 @@ a タグ には target=\_blank という設定があり、別タブで開かせ�
 </a>
 ```
 
-そこには `rel="noreferrer noreferrer"` を付けようという話があり、
+そこには `rel="noopener noreferrer"` を付けようという話があり、
 
 ```jsx
-<a href="http://example.com" target="_blank" rel="noreferrer noreferrer">
+<a href="http://example.com" target="_blank" rel="noopener noreferrer">
   アンカーリンク
 </a>
 ```


### PR DESCRIPTION
## 変更内容

こちらの記事に誤字と思われるものを見つけたので、PRさせていただきました。
https://blog.ojisan.io/noreferrer-noopener

`noreferrer noreferrer` となっていた箇所を、本文後半を参考に `noopener noreferrer` に修正しました。