### PR TITLE
Edit the CONTRIBUTE link in README -READMEのCONTRIBUTEリンクを有効化しました

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,4 +34,4 @@ deploy 自体は master に merge されると自動でデプロイされる on 
 
 ## How To Contribute
 
-[CONTRIBUTING]()
+[CONTRIBUTING](https://github.com/sadnessOjisan/blog.ojisan.io/blob/master/.github/CONTRIBUTING.md)


### PR DESCRIPTION
## 参照 -Reference
こちらのissue #153 を参照しました
refer to #153 

## 変更内容
The CONTRIBUTE link in the README was invalid and has been fixed.
READMEのCONTRIBUTEリンクが無効になっていた為、修正いたしました