### PR TITLE
`word-break: break-all;` は即刻中止せよ

### DIFF
--- a/src/components/indices/card.tsx
+++ b/src/components/indices/card.tsx
@@ -77,7 +77,7 @@ const StyledComponent = styled(Component)<{ isHover: boolean }>`
     font-size: 24px;
     font-weight: 600;
     margin-top: 12px;
-    word-break: break-all;
+    overflow-wrap: break-word;
   }
 
   & .excerpt {

--- a/src/templates/blogTemplate.tsx
+++ b/src/templates/blogTemplate.tsx
@@ -237,7 +237,7 @@ const StyledComponent = styled(Component)`
   & .content > ul,
   & .content > blockquote {
     margin-bottom: 20px;
-    word-break: break-all;
+    overflow-wrap: break-word;
   }
 
   & .content > h1,
@@ -245,7 +245,7 @@ const StyledComponent = styled(Component)`
   & .content > h3,
   & .content > h4 {
     margin-bottom: 12px;
-    word-break: break-all;
+    overflow-wrap: break-word;
   }
 
   & .content li {


### PR DESCRIPTION
<!--

修正PRはここからできます。
バグ報告は Issue からお願いします。

-->

## 変更内容

<!-- ex)誤字を見つけた -->

`word-break: break-all;` だと英単語も強制的に改行するので `overflow-wrap: break-word;` に変更。

<table>
<tr>
	<td><code>word-break: break-all;</code>
	<td><code>overflow-wrap: break-word;</code>
<tr>
	<td><img width="405" alt="Screen Shot 2021-05-18 at 22 12 00" src="https://user-images.githubusercontent.com/1996642/118657129-28572580-b826-11eb-8bad-32770d9bea12.png">
	<td><img width="413" alt="Screen Shot 2021-05-18 at 22 12 09" src="https://user-images.githubusercontent.com/1996642/118657166-31e08d80-b826-11eb-90f6-fe7dce208cb8.png">
</table>

URLも改行されます
<img width="397" alt="Screen Shot 2021-05-18 at 22 14 55" src="https://user-images.githubusercontent.com/1996642/118657534-897ef900-b826-11eb-89f8-f51a2af29732.png">


IE11対応もバッチリです
https://developer.mozilla.org/ja/docs/Web/CSS/overflow-wrap