### PR TITLE
fix: rename tags

### DIFF
--- a/src/contents/20200618-how-to-read-js/index.md
+++ b/src/contents/20200618-how-to-read-js/index.md
@@ -3,7 +3,7 @@ path: /how-to-read-js
 created: "2020-06-18"
 title: JavaScriptライブラリを読むときのコツ
 visual: "./visual.png"
-tags: [javaScript, nodejs]
+tags: [javascript, nodejs]
 userId: sadnessOjisan
 isFavorite: true
 isProtect: false

--- a/src/contents/20200817-usefish/index.md
+++ b/src/contents/20200817-usefish/index.md
@@ -3,7 +3,7 @@ path: /to-fish
 created: "2020-08-17 15:00"
 title: fishを使ってみて分かったメリットや設定のコツ
 visual: "./visual.png"
-tags: [fish, dotfile]
+tags: [fish, dotfiles]
 userId: sadnessOjisan
 isFavorite: false
 isProtect: false

--- a/src/contents/20200909-gha-ghpage/index.md
+++ b/src/contents/20200909-gha-ghpage/index.md
@@ -3,7 +3,7 @@ path: /gha-ghpage
 created: "2020-09-09"
 title: GitHub Actions と GitHub Pages で yml をフォルダに入れておくだけのお手軽デプロイ
 visual: "./visual.png"
-tags: ["gitHub actions", "gitHub pages"]
+tags: ["github-actions", "github-pages"]
 userId: sadnessOjisan
 isFavorite: false
 isProtect: false

--- a/src/contents/20201216-ts-cbor/index.md
+++ b/src/contents/20201216-ts-cbor/index.md
@@ -3,7 +3,7 @@ path: /ts-cbor
 created: "2020-12-16"
 title: RFCからCBORのデコーダーを作る
 visual: "./visual.png"
-tags: ["node.js"]
+tags: ["nodejs"]
 userId: sadnessOjisan
 isFavorite: false
 isProtect: false

--- a/src/contents/20210418-fish-node/index.md
+++ b/src/contents/20210418-fish-node/index.md
@@ -3,7 +3,7 @@ path: /fish-node
 created: "2021-04-18"
 title: fish で Node.js を使う
 visual: "./visual.png"
-tags: ["fish", "node.js"]
+tags: ["fish", "nodejs"]
 userId: sadnessOjisan
 isFavorite: false
 isProtect: false

--- a/src/contents/20210705-node-bin-order/index.md
+++ b/src/contents/20210705-node-bin-order/index.md
@@ -3,7 +3,7 @@ path: /node-bin-order
 created: "2021-07-05"
 title: 同名の bin script を持つ package を install するとどうなるのか？
 visual: "./visual.png"
-tags: ["node.js"]
+tags: ["nodejs"]
 userId: sadnessOjisan
 isFavorite: false
 isProtect: false

--- a/src/contents/20220907-node-oauth-client/index.md
+++ b/src/contents/20220907-node-oauth-client/index.md
@@ -3,7 +3,7 @@ path: /node-oauth2-client
 created: "2022-09-07"
 title: Node.js の OAuth2.0 クライアントを自作する
 visual: "./visual.png"
-tags: ["node.js", "oauth2.0"]
+tags: ["nodejs", "oauth2.0"]
 userId: sadnessOjisan
 isFavorite: false
 isProtect: false

--- a/src/contents/20230810-actions-rs-cargo-ari-nashi/index.md
+++ b/src/contents/20230810-actions-rs-cargo-ari-nashi/index.md
@@ -3,7 +3,7 @@ path: /actions-rs-cargo-ari-nashi
 created: "2023-08-10"
 title: actions-rs/cargo が非推奨とは言うものの 
 visual: "./visual.png"
-tags: [rust, "github actions"]
+tags: [rust, "github-actions"]
 userId: sadnessOjisan
 isFavorite: false
 isProtect: false


### PR DESCRIPTION
## 説明

同じ内容と思われるタグに表記揺れがあったので統一してみました！

### 変更方針

- 記事数の多い方に寄せる
- 小文字に統一
- 好み

### 詳細

- `javascript` に統一
    - `javaScript` `javascript`
- `dotfiles` に統一
    - `dotfile` `dotfiles`
- `github-*` に統一
    - `gitHub actions` `gitHub pages` `github actions` `github-actions`
- `nodejs` に統一
    - `node.js` `nodejs`
