### PR TITLE
fix: rss feed

### DIFF
--- a/gatsby-config.ts
+++ b/gatsby-config.ts
@@ -16,6 +16,15 @@ const config: GatsbyConfig = {
     {
       resolve: `gatsby-plugin-feed`,
       options: {
+        setup: (options) => ({
+          ...options,
+          custom_elements: [
+            {
+              [`atom:link href="${options.query.site.siteMetadata.siteUrl}${options.output}" rel="self" type="application/rss+xml"`]:
+                null,
+            },
+          ],
+        }),
         query: `
           {
             site {
@@ -47,17 +56,15 @@ const config: GatsbyConfig = {
                   url: site?.siteMetadata?.siteUrl + edge.node.frontmatter.path,
                   guid:
                     site?.siteMetadata?.siteUrl + edge.node.frontmatter.path,
-                  custom_elements: [{ "content:encoded": edge.node.html }],
                 });
               });
             },
             query: `
               {
-                allMarkdownRemark(sort: {frontmatter: {created: DESC}}) {
+                allMarkdownRemark(sort: {frontmatter: {created: DESC}}, limit: 10) {
                   edges {
                     node {
                       excerpt
-                      html
                       frontmatter {
                         path
                         title


### PR DESCRIPTION
## 説明

Feed Validatorでエラーが出ていたのでRSSの出力内容を変更してみました。

https://validator.w3.org/feed/check.cgi?url=https%3A%2F%2Fblog.ojisan.io%2Frss.xml

### やったこと

- `content:encoded` の削除
    - `description` があればひとまず問題なさそうなので削除
- `atom:link` の追加
    - なくても問題なさそうだがValidatorが推奨するので追加
- `limit: 10` の追加
    - 全件出力すると容量が肥大化するため最新10件に制限

### スクリーンショット

| Before | After |
|--------|--------|
| <img width="1450" alt="スクリーンショット 2023-08-12 23 56 54" src="https://github.com/sadnessOjisan/blog.ojisan.io/assets/3946829/865ed6ff-e48c-4d05-aabd-3c093697c621"> | <img width="1450" alt="スクリーンショット 2023-08-12 23 56 58" src="https://github.com/sadnessOjisan/blog.ojisan.io/assets/3946829/53aadcee-54eb-4bdc-aae6-7c89e0cae7e0"> |

`atom:link` 部分にRecommendationsが出ていますが、これはRSSの内容を直接入力で検査したため、linkの検査ができないことが理由だと考えています。