### PR TITLE
ogpの設定を修正

### DIFF
--- a/src/components/common/head.tsx
+++ b/src/components/common/head.tsx
@@ -51,14 +51,14 @@ export const HeadFactory: ComponentType<Props> = ({
     throw new Error("data source is invalid");
   }
   const pageTitle = title ? `${title} | ${baseData.title}` : baseData.title;
-  const pageDiscription = description ? description : baseData.description;
+  const pageDescription = description ? description : baseData.description;
   const pageImage = imagePath ? imagePath : baseData.image;
   const pageUrl = path ? `${baseData.siteUrl}${path}` : baseData.siteUrl;
   return (
     <>
       <title>{pageTitle}</title>
       <meta property="og:title" content={title} />
-      <meta name="og:description" content={pageDiscription} />
+      <meta property="og:description" content={pageDescription} />
       <meta property="og:url" content={pageUrl} />
       <meta property="og:type" content={type} />
       <meta property="og:site_name" content={baseData.title} />

--- a/src/components/common/head.tsx
+++ b/src/components/common/head.tsx
@@ -8,6 +8,7 @@ interface Props {
   created?: string;
   type: "blog" | "article";
   shouldProtect?: boolean;
+  path?: string;
 }
 
 /**
@@ -21,6 +22,7 @@ export const HeadFactory: ComponentType<Props> = ({
   type,
   created,
   shouldProtect,
+  path,
 }) => {
   // 他の場所でも呼び出すなら custom hooks として切り出すべき
   const siteMetaDataQueryResult: Queries.SiteMetaDataQuery = useStaticQuery(
@@ -51,17 +53,18 @@ export const HeadFactory: ComponentType<Props> = ({
   const pageTitle = title ? `${title} | ${baseData.title}` : baseData.title;
   const pageDiscription = description ? description : baseData.description;
   const pageImage = imagePath ? imagePath : baseData.image;
+  const pageUrl = path ? `${baseData.siteUrl}${path}` : baseData.siteUrl;
   return (
     <>
       <title>{pageTitle}</title>
       <meta property="og:title" content={title} />
       <meta name="og:description" content={pageDiscription} />
-      <meta property="og:url" content={baseData.siteUrl} />
+      <meta property="og:url" content={pageUrl} />
       <meta property="og:type" content={type} />
       <meta property="og:site_name" content={baseData.title} />
       <meta property="og:image" content={`${baseData.siteUrl}${pageImage}`} />
       <meta name="twitter:card" content="summary_large_image" />
-      <meta name="twitter:url" content={baseData.siteUrl} />
+      <meta name="twitter:url" content={pageUrl} />
       <meta name="twitter:site" content={baseData.twitterUsername} />
       {shouldProtect && <meta name="Hatena::Bookmark" content="nocomment" />}
       {type === "article" && (

--- a/src/templates/detail-page.tsx
+++ b/src/templates/detail-page.tsx
@@ -109,6 +109,7 @@ export const Head = ({ data }: HeadProps<Queries.DetailPageQueryQuery>) => {
       created={data.markdownRemark.frontmatter?.created}
       shouldProtect={!!data.markdownRemark.frontmatter.isProtect}
       description={data.markdownRemark.excerpt}
+      path={`${data.markdownRemark.frontmatter.path}/`}
     />
   );
 };


### PR DESCRIPTION
## 説明

- `meta[property="og:url"]` `meta[name="twitter:url"]` が siteUrl を参照していたので、記事ページは path と結合するように変更
- `og:description` の指定がname属性になっていたので、property属性に変更

## 差分

| Before | After |
| :--: | :--: |
| ![Before](https://github.com/sadnessOjisan/blog.ojisan.io/assets/3946829/0881937e-3811-4bc0-9083-ff077016c8da) | ![After](https://github.com/sadnessOjisan/blog.ojisan.io/assets/3946829/51cb9430-52d9-4cb5-ba6a-4556d12e3c00) |

`meta[property="og:description"]` `meta[property="og:url"]` `meta[name="twitter:url"]` のみ